### PR TITLE
Switch dirs before deleting current dir in script

### DIFF
--- a/scripts/workshop-setup.sh
+++ b/scripts/workshop-setup.sh
@@ -173,13 +173,12 @@ function cacheStacks {
     (appsody run --name workshop_prep_container) & sleep ${sleepTime} ; kill -9 $!
     appsody stop --name workshop_prep_container
 
+    cd ${original_dir}
     rm -rf ${app_dir}
     docker rmi ${app_name}:latest
 
     echo "INFO: Clearing all temporary content"
     appsody repo remove ${appsody_repo}
-
-    cd ${original_dir}
 }
 
 


### PR DESCRIPTION
On Ubuntu, script failing with:

`Error getting current directory:  getwd: no such file or directory`